### PR TITLE
Allow setting db and table name for existing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ This project constitutes a work of the United States Government and is not subje
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_bytes_scanned_cutoff_per_query"></a> [bytes\_scanned\_cutoff\_per\_query](#input\_bytes\_scanned\_cutoff\_per\_query) | Integer for the upper data usage limit (cutoff) for the amount of bytes a single query in a workgroup is allowed to scan. Must be at least 10485760. | `number` | `-1` | no |
+| <a name="input_database_name"></a> [database\_name](#input\_database\_name) | The name of an existing database. If none exists then a new athena database will be created. | `string` | `""` | no |
 | <a name="input_logging_bucket"></a> [logging\_bucket](#input\_logging\_bucket) | The S3 bucket to send logs for query results bucket | `string` | n/a | yes |
 | <a name="input_project"></a> [project](#input\_project) | Unique name for the set of logs being analyzed | `string` | `"s3-access-logs"` | no |
+| <a name="input_table_name"></a> [table\_name](#input\_table\_name) | The name of an existing table. If none exists then a new athena database will be created. | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources | `map(string)` | <pre>{<br>  "Automation": "Terraform"<br>}</pre> | no |
 | <a name="input_target_bucket"></a> [target\_bucket](#input\_target\_bucket) | The S3 bucket to target for s3 access logs. | `string` | n/a | yes |
 | <a name="input_target_prefix"></a> [target\_prefix](#input\_target\_prefix) | The S3 prefix to target for s3 access logs | `string` | `"s3"` | no |

--- a/main.tf
+++ b/main.tf
@@ -77,10 +77,14 @@ module "athena_workgroup" {
 }
 
 locals {
-  db_name = replace(var.project, "-", "_")
+  db_name    = length(var.database_name) > 0 ? var.database_name : replace(var.project, "-", "_")
+  table_name = length(var.table_name) > 0 ? var.table_name : local.db_name
 }
 
 resource "aws_athena_database" "access_logs" {
+  # Create only if DB name is not given
+  count = length(var.database_name) > 0 ? 0 : 1
+
   # https://docs.aws.amazon.com/athena/latest/ug/tables-databases-columns-names.html
   name   = local.db_name
   bucket = module.query_results.id

--- a/queries.tf
+++ b/queries.tf
@@ -2,14 +2,14 @@
 # Queries copied from https://aws.amazon.com/premiumsupport/knowledge-center/analyze-logs-athena/
 
 locals {
-  queries = [
+  queries = compact([
     "actions_by_user",
-    "create_table",
+    length(var.database_name) > 0 ? "" : "create_table",
     "log_deleted_object",
     "operations_on_object",
     "show_data_transfer_by_ip",
     "who_deleted_object",
-  ]
+  ])
 }
 
 data "template_file" "query" {
@@ -18,7 +18,7 @@ data "template_file" "query" {
   template = file("${path.module}/query_templates/${local.queries[count.index]}.tmpl")
   vars = {
     account_id              = data.aws_caller_identity.current.account_id
-    database_and_table_name = format("%s.%s", local.db_name, local.db_name)
+    database_and_table_name = format("%s.%s", local.db_name, local.table_name)
     partition               = data.aws_partition.current.partition
     target_location         = format("%s/%s", var.target_bucket, var.target_prefix)
   }
@@ -31,6 +31,6 @@ resource "aws_athena_named_query" "query" {
   name        = local.queries[count.index]
   description = format("%s for querying s3 access logs", local.queries[count.index])
   workgroup   = module.athena_workgroup.id
-  database    = aws_athena_database.access_logs.name
+  database    = length(var.database_name) > 0 ? local.db_name : aws_athena_database.access_logs[0].name
   query       = data.template_file.query[count.index].rendered
 }

--- a/query_templates/show_data_transfer_by_ip.tmpl
+++ b/query_templates/show_data_transfer_by_ip.tmpl
@@ -1,6 +1,8 @@
-SELECT SUM(bytessent) as uploadtotal,
+SELECT remoteip,
+SUM(bytessent) as uploadtotal,
 SUM(objectsize) as downloadtotal,
 SUM(bytessent + objectsize) AS total
 FROM ${ database_and_table_name }
-WHERE remoteIP='1.2.3.4' and parse_datetime(requestdatetime,'dd/MMM/yyyy:HH:mm:ss Z')
-BETWEEN parse_datetime('2020-07-01','yyyy-MM-dd') and parse_datetime('2020-08-01','yyyy-MM-dd');
+WHERE parse_datetime(requestdatetime,'dd/MMM/yyyy:HH:mm:ss Z')
+BETWEEN parse_datetime('2020-07-01','yyyy-MM-dd') and parse_datetime('2020-08-01','yyyy-MM-dd')
+GROUP BY remoteip;

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,18 @@ variable "bytes_scanned_cutoff_per_query" {
   default     = -1
 }
 
+variable "database_name" {
+  type        = string
+  description = "The name of an existing database. If none exists then a new athena database will be created."
+  default     = ""
+}
+
+variable "table_name" {
+  type        = string
+  description = "The name of an existing table. If none exists then a new athena database will be created."
+  default     = ""
+}
+
 variable "tags" {
   type        = map(string)
   description = "A mapping of tags to assign to the resources"


### PR DESCRIPTION
When using a glue DB with an existing table we need to point athena queries at it instead of creating a new table.